### PR TITLE
Add security headers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# LA1TV Website Frontend
+
+## Quick Links
+
+* [Deployment](./deployment.md)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,5 @@
+# Deploying the Frontend
+
+[Back to README](./README.md)
+
+When deploying we need to set `process.env.UPGRADE_INSECURE_REQUESTS`, This forces any connection out of the page to be https calls.

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "index.js",
   "scripts": {
     "coveralls": "echo 'coveralls coming soon'",
-    "dev": "next",
     "build": "next build",
     "lint": "eslint ./",
     "jest": "jest --coverage",
-    "start": "next start",
-    "test": "yarn lint"
+    "test": "yarn lint",
+    "dev": "node server.js",
+    "start": "NODE_ENV=production node server.js"
   },
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -17,6 +17,6 @@ app.prepare().then(() => {
     app.render(req, res, pathname, query)
   }).listen(port, err => {
     if (err) throw err
-    console.log(`> Ready on http://localhost:${port}`)
+    console.log(`✅ Ready on http://localhost:${port}`)
   })
 })

--- a/server.js
+++ b/server.js
@@ -17,6 +17,6 @@ app.prepare().then(() => {
     app.render(req, res, pathname, query)
   }).listen(port, err => {
     if (err) throw err
-    console.log(`✅ Ready on http://localhost:${port}`)
+    console.log(`🚀 Ready on http://localhost:${port}`)
   })
 })

--- a/server.js
+++ b/server.js
@@ -1,0 +1,22 @@
+const { createServer } = require('http')
+const { parse } = require('url')
+const next = require('next')
+const { setHeaders } = require('./utilities/headers')
+
+const port = parseInt(process.env.PORT, 10) || 3000
+const dev = process.env.NODE_ENV !== 'production'
+const app = next({ dev })
+
+app.prepare().then(() => {
+  createServer((req, res) => {
+    const parsedUrl = parse(req.url, true)
+    const { pathname, query } = parsedUrl
+
+    setHeaders(res)
+
+    app.render(req, res, pathname, query)
+  }).listen(port, err => {
+    if (err) throw err
+    console.log(`> Ready on http://localhost:${port}`)
+  })
+})

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 const { createServer } = require('http')
-const { parse } = require('url')
+const { parse } = require('url') /* eslint-disable-line node/no-deprecated-api */
 const next = require('next')
 const setHeaders = require('./utilities/headers')
 
@@ -9,8 +9,7 @@ const app = next({ dev })
 
 app.prepare().then(() => {
   createServer((req, res) => {
-    const parsedUrl = parse(req.url, true)
-    const { pathname, query } = parsedUrl
+    const { pathname, query } = parse(req.url, true)
 
     setHeaders(res)
 

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 const { createServer } = require('http')
 const { parse } = require('url')
 const next = require('next')
-const { setHeaders } = require('./utilities/headers')
+const setHeaders = require('./utilities/headers')
 
 const port = parseInt(process.env.PORT, 10) || 3000
 const dev = process.env.NODE_ENV !== 'production'

--- a/utilities/headers/index.js
+++ b/utilities/headers/index.js
@@ -5,13 +5,13 @@ const featurePolicy = require('./lib/feature-policy')
 const contentSecurityPolicy = require('./lib/content-security-policy')
 
 const setHeaders = (res) => {
-  if (process.env.LIVE === 'true') {
+  if (process.env.LIVE) {
     res.setHeader(...strictTransportSecurity)
   }
   res.setHeader(...contentTypeOptions)
   res.setHeader(...referrerPolicy)
   res.setHeader(...featurePolicy)
-  res.setHeader(...contentSecurityPolicy)
+  res.setHeader(...contentSecurityPolicy())
 }
 
-module.exports = { setHeaders }
+module.exports = setHeaders

--- a/utilities/headers/index.js
+++ b/utilities/headers/index.js
@@ -1,0 +1,17 @@
+const strictTransportSecurity = require('./lib/strict-transport-security')
+const contentTypeOptions = require('./lib/content-type-options')
+const referrerPolicy = require('./lib/referrer-policy')
+const featurePolicy = require('./lib/feature-policy')
+const contentSecurityPolicy = require('./lib/content-security-policy')
+
+const setHeaders = (res) => {
+  if (process.env.LIVE === 'true') {
+    res.setHeader(...strictTransportSecurity)
+  }
+  res.setHeader(...contentTypeOptions)
+  res.setHeader(...referrerPolicy)
+  res.setHeader(...featurePolicy)
+  res.setHeader(...contentSecurityPolicy)
+}
+
+module.exports = { setHeaders }

--- a/utilities/headers/index.js
+++ b/utilities/headers/index.js
@@ -5,9 +5,7 @@ const featurePolicy = require('./lib/feature-policy')
 const contentSecurityPolicy = require('./lib/content-security-policy')
 
 const setHeaders = (res) => {
-  if (process.env.LIVE) {
-    res.setHeader(...strictTransportSecurity)
-  }
+  res.setHeader(...strictTransportSecurity)
   res.setHeader(...contentTypeOptions)
   res.setHeader(...referrerPolicy)
   res.setHeader(...featurePolicy)

--- a/utilities/headers/index.js
+++ b/utilities/headers/index.js
@@ -3,6 +3,7 @@ const contentTypeOptions = require('./lib/content-type-options')
 const referrerPolicy = require('./lib/referrer-policy')
 const featurePolicy = require('./lib/feature-policy')
 const contentSecurityPolicy = require('./lib/content-security-policy')
+const xssProtectionPolicy = require('./lib/xss-protection')
 
 const setHeaders = (res) => {
   res.setHeader(...strictTransportSecurity)
@@ -10,6 +11,7 @@ const setHeaders = (res) => {
   res.setHeader(...referrerPolicy)
   res.setHeader(...featurePolicy)
   res.setHeader(...contentSecurityPolicy())
+  res.setHeader(...xssProtectionPolicy)
 }
 
 module.exports = setHeaders

--- a/utilities/headers/lib/config/content-security-policy-config.js
+++ b/utilities/headers/lib/config/content-security-policy-config.js
@@ -1,0 +1,67 @@
+const liveOnlyHeading = () => process.env.LIVE
+  ? [
+    {
+      name: 'upgrade-insecure-requests'
+    }
+  ]
+  : []
+
+const devOnlyHeading = () => !process.env.PRODUCTION
+  ? [
+    {
+      name: 'connect-src',
+      value: ["'self'"]
+    }
+  ]
+  : []
+
+const contentSecurityPolicyConfig = () => ([
+  {
+    name: 'default-src',
+    value: ["'none'"]
+  },
+  {
+    name: 'script-src',
+    value: ["'self'", "'unsafe-inline'"]
+  },
+  {
+    name: 'style-src',
+    value: ["'unsafe-inline'"]
+  },
+  {
+    name: 'img-src',
+    value: ["'self'"]
+  },
+  {
+    name: 'frame-src',
+    value: ['embed.la1tv.co.uk']
+  },
+  {
+    name: 'object-src',
+    value: ["'none'"]
+  },
+  {
+    name: 'worker-src',
+    value: ["'self'"]
+  },
+  {
+    name: 'manifest-src',
+    value: ["'self'"]
+  },
+  {
+    name: 'base-uri',
+    value: ["'none'"]
+  },
+  {
+    name: 'form-action',
+    value: ["'none'"]
+  },
+  {
+    name: 'frame-ancestors',
+    value: ["'none'"]
+  },
+  ...liveOnlyHeading(),
+  ...devOnlyHeading()
+])
+
+module.exports = contentSecurityPolicyConfig

--- a/utilities/headers/lib/config/content-security-policy-config.js
+++ b/utilities/headers/lib/config/content-security-policy-config.js
@@ -1,4 +1,4 @@
-const liveOnlyHeading = () => process.env.LIVE
+const liveOnlyHeading = () => process.env.UPGRADE_INSECURE_REQUESTS
   ? [
     {
       name: 'upgrade-insecure-requests'

--- a/utilities/headers/lib/config/feature-policy-config.js
+++ b/utilities/headers/lib/config/feature-policy-config.js
@@ -1,0 +1,72 @@
+const featurePolicyConfig = [
+  {
+    name: 'ambient-light-sensor',
+    value: ["'none'"]
+  },
+  {
+    name: 'autoplay',
+    value: ["'none'"]
+  },
+  {
+    name: 'accelerometer',
+    value: ["'none'"]
+  },
+  {
+    name: 'camera',
+    value: ["'none'"]
+  },
+  {
+    name: 'encrypted-media',
+    value: ["'none'"]
+  },
+  {
+    name: 'fullscreen',
+    value: ["'none'"]
+  },
+  {
+    name: 'geolocation',
+    value: ["'none'"]
+  },
+  {
+    name: 'gyroscope',
+    value: ["'none'"]
+  },
+  {
+    name: 'magnetometer',
+    value: ["'none'"]
+  },
+  {
+    name: 'microphone',
+    value: ["'none'"]
+  },
+  {
+    name: 'midi',
+    value: ["'none'"]
+  },
+  {
+    name: 'payment',
+    value: ["'none'"]
+  },
+  {
+    name: 'picture-in-picture',
+    value: ["'none'"]
+  },
+  {
+    name: 'speaker',
+    value: ["'none'"]
+  },
+  {
+    name: 'sync-xhr',
+    value: ["'none'"]
+  },
+  {
+    name: 'usb',
+    value: ["'none'"]
+  },
+  {
+    name: 'vr',
+    value: ["'none'"]
+  }
+]
+
+module.exports = featurePolicyConfig

--- a/utilities/headers/lib/content-security-policy.js
+++ b/utilities/headers/lib/content-security-policy.js
@@ -1,6 +1,6 @@
 const policyConfigParser = require('./helper/config-parser')
 const contentSecurityPolicyConfig = require('./config/content-security-policy-config')
 
-const contentSecurityPolicy = () => ['Content-Security-Policy', policyConfigParser(contentSecurityPolicyConfig())]
+const contentSecurityPolicyHeader = () => ['Content-Security-Policy', policyConfigParser(contentSecurityPolicyConfig())]
 
-module.exports = contentSecurityPolicy
+module.exports = contentSecurityPolicyHeader

--- a/utilities/headers/lib/content-security-policy.js
+++ b/utilities/headers/lib/content-security-policy.js
@@ -1,6 +1,6 @@
 const policyConfigParser = require('./helper/config-parser')
 const contentSecurityPolicyConfig = require('./config/content-security-policy-config')
 
-const contentSecurityPolicy = ['Content-Security-Policy', policyConfigParser(contentSecurityPolicyConfig())]
+const contentSecurityPolicy = () => ['Content-Security-Policy', policyConfigParser(contentSecurityPolicyConfig())]
 
 module.exports = contentSecurityPolicy

--- a/utilities/headers/lib/content-security-policy.js
+++ b/utilities/headers/lib/content-security-policy.js
@@ -1,0 +1,6 @@
+const policyConfigParser = require('./helper/config-parser')
+const contentSecurityPolicyConfig = require('./config/content-security-policy-config')
+
+const contentSecurityPolicy = ['Content-Security-Policy', policyConfigParser(contentSecurityPolicyConfig())]
+
+module.exports = contentSecurityPolicy

--- a/utilities/headers/lib/content-type-options.js
+++ b/utilities/headers/lib/content-type-options.js
@@ -1,3 +1,3 @@
-const hstsHeader = ['X-Content-Type-Options', 'nosniff']
+const contentTypeOptions = ['X-Content-Type-Options', 'nosniff']
 
-module.exports = hstsHeader
+module.exports = contentTypeOptions

--- a/utilities/headers/lib/content-type-options.js
+++ b/utilities/headers/lib/content-type-options.js
@@ -1,0 +1,3 @@
+const hstsHeader = ['X-Content-Type-Options', 'nosniff']
+
+module.exports = hstsHeader

--- a/utilities/headers/lib/feature-policy.js
+++ b/utilities/headers/lib/feature-policy.js
@@ -1,0 +1,6 @@
+const policyConfigParser = require('./helper/config-parser')
+const featurePolicyConfig = require('./config/feature-policy-config')
+
+const featurePolicy = ['Feature-Policy', policyConfigParser(featurePolicyConfig)]
+
+module.exports = featurePolicy

--- a/utilities/headers/lib/helper/config-parser.js
+++ b/utilities/headers/lib/helper/config-parser.js
@@ -1,0 +1,12 @@
+const combinePolicyDirectives = ({ name, value }) => {
+  if (!value) return `${name};`
+  const combinedValues = value.join(' ')
+  return `${name} ${combinedValues};`
+}
+
+const policyConfigParser = (config) => {
+  const combinedPolicyDirectives = config.map(combinePolicyDirectives)
+  return combinedPolicyDirectives.join([' '])
+}
+
+module.exports = policyConfigParser

--- a/utilities/headers/lib/referrer-policy.js
+++ b/utilities/headers/lib/referrer-policy.js
@@ -1,0 +1,3 @@
+const hstsHeader = ['Referrer-Policy', 'no-referrer']
+
+module.exports = hstsHeader

--- a/utilities/headers/lib/referrer-policy.js
+++ b/utilities/headers/lib/referrer-policy.js
@@ -1,3 +1,3 @@
-const hstsHeader = ['Referrer-Policy', 'no-referrer']
+const referrerPolicyHeader = ['Referrer-Policy', 'no-referrer']
 
-module.exports = hstsHeader
+module.exports = referrerPolicyHeader

--- a/utilities/headers/lib/strict-transport-security.js
+++ b/utilities/headers/lib/strict-transport-security.js
@@ -1,0 +1,5 @@
+const cacheInSecond = 10
+
+const hstsHeader = ['Strict-Transport-Security', `max-age=${cacheInSecond}`]
+
+module.exports = hstsHeader

--- a/utilities/headers/lib/strict-transport-security.js
+++ b/utilities/headers/lib/strict-transport-security.js
@@ -1,4 +1,4 @@
-const cacheInSecond = 10
+const cacheInSecond = 5256000
 
 const hstsHeader = ['Strict-Transport-Security', `max-age=${cacheInSecond}`]
 

--- a/utilities/headers/lib/strict-transport-security.js
+++ b/utilities/headers/lib/strict-transport-security.js
@@ -1,4 +1,4 @@
-const cacheInSecond = 5256000
+const cacheInSecond = 15768000
 
 const hstsHeader = ['Strict-Transport-Security', `max-age=${cacheInSecond}`]
 

--- a/utilities/headers/lib/strict-transport-security.js
+++ b/utilities/headers/lib/strict-transport-security.js
@@ -1,5 +1,5 @@
 const cacheInSecond = 15768000
 
-const hstsHeader = ['Strict-Transport-Security', `max-age=${cacheInSecond}`]
+const strictTransportSecurityHeader = ['Strict-Transport-Security', `max-age=${cacheInSecond}`]
 
-module.exports = hstsHeader
+module.exports = strictTransportSecurityHeader

--- a/utilities/headers/lib/xss-protection.js
+++ b/utilities/headers/lib/xss-protection.js
@@ -1,0 +1,3 @@
+const xssProtectionHeader = ['X-XSS-Protection', '1; mode=block']
+
+module.exports = xssProtectionHeader

--- a/utilities/headers/test/sets-headers.test.js
+++ b/utilities/headers/test/sets-headers.test.js
@@ -9,6 +9,7 @@ test('sets headers', () => {
 
   const expectedFeaturePolicy = "ambient-light-sensor 'none'; autoplay 'none'; accelerometer 'none'; camera 'none'; encrypted-media 'none'; fullscreen 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi 'none'; payment 'none'; picture-in-picture 'none'; speaker 'none'; sync-xhr 'none'; usb 'none'; vr 'none';"
   const expectedContentSecurityPolicy = "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self'; frame-src embed.la1tv.co.uk; object-src 'none'; worker-src 'self'; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; connect-src 'self';"
+  expect(mockRes.setHeader).toHaveBeenCalledWith('Strict-Transport-Security', `max-age=5256000`)
   expect(mockRes.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', 'nosniff')
   expect(mockRes.setHeader).toHaveBeenCalledWith('Referrer-Policy', 'no-referrer')
   expect(mockRes.setHeader).toHaveBeenCalledWith('Feature-Policy', expectedFeaturePolicy)
@@ -20,15 +21,14 @@ test('sets live headers', () => {
     setHeader: jest.fn()
   }
 
-  process.env.LIVE = 'true'
+  process.env.UPGRADE_INSECURE_REQUESTS = 'true'
 
   setHeaders(mockRes)
 
   const expectedLiveContentSecurityPolicy = "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self'; frame-src embed.la1tv.co.uk; object-src 'none'; worker-src 'self'; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests; connect-src 'self';"
-  expect(mockRes.setHeader).toHaveBeenCalledWith('Strict-Transport-Security', `max-age=10`)
   expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Security-Policy', expectedLiveContentSecurityPolicy)
 
-  delete process.env.LIVE
+  delete process.env.UPGRADE_INSECURE_REQUESTS
 })
 
 test('sets production headers', () => {

--- a/utilities/headers/test/sets-headers.test.js
+++ b/utilities/headers/test/sets-headers.test.js
@@ -14,6 +14,7 @@ test('sets headers', () => {
   expect(mockRes.setHeader).toHaveBeenCalledWith('Referrer-Policy', 'no-referrer')
   expect(mockRes.setHeader).toHaveBeenCalledWith('Feature-Policy', expectedFeaturePolicy)
   expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Security-Policy', expectedContentSecurityPolicy)
+  expect(mockRes.setHeader).toHaveBeenCalledWith('X-XSS-Protection', '1; mode=block')
 })
 
 test('sets live headers', () => {

--- a/utilities/headers/test/sets-headers.test.js
+++ b/utilities/headers/test/sets-headers.test.js
@@ -9,7 +9,7 @@ test('sets headers', () => {
 
   const expectedFeaturePolicy = "ambient-light-sensor 'none'; autoplay 'none'; accelerometer 'none'; camera 'none'; encrypted-media 'none'; fullscreen 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi 'none'; payment 'none'; picture-in-picture 'none'; speaker 'none'; sync-xhr 'none'; usb 'none'; vr 'none';"
   const expectedContentSecurityPolicy = "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self'; frame-src embed.la1tv.co.uk; object-src 'none'; worker-src 'self'; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; connect-src 'self';"
-  expect(mockRes.setHeader).toHaveBeenCalledWith('Strict-Transport-Security', `max-age=5256000`)
+  expect(mockRes.setHeader).toHaveBeenCalledWith('Strict-Transport-Security', `max-age=15768000`)
   expect(mockRes.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', 'nosniff')
   expect(mockRes.setHeader).toHaveBeenCalledWith('Referrer-Policy', 'no-referrer')
   expect(mockRes.setHeader).toHaveBeenCalledWith('Feature-Policy', expectedFeaturePolicy)

--- a/utilities/headers/test/sets-headers.test.js
+++ b/utilities/headers/test/sets-headers.test.js
@@ -1,0 +1,47 @@
+const setHeaders = require('../index')
+
+test('sets headers', () => {
+  const mockRes = {
+    setHeader: jest.fn()
+  }
+
+  setHeaders(mockRes)
+
+  const expectedFeaturePolicy = "ambient-light-sensor 'none'; autoplay 'none'; accelerometer 'none'; camera 'none'; encrypted-media 'none'; fullscreen 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; midi 'none'; payment 'none'; picture-in-picture 'none'; speaker 'none'; sync-xhr 'none'; usb 'none'; vr 'none';"
+  const expectedContentSecurityPolicy = "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self'; frame-src embed.la1tv.co.uk; object-src 'none'; worker-src 'self'; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; connect-src 'self';"
+  expect(mockRes.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', 'nosniff')
+  expect(mockRes.setHeader).toHaveBeenCalledWith('Referrer-Policy', 'no-referrer')
+  expect(mockRes.setHeader).toHaveBeenCalledWith('Feature-Policy', expectedFeaturePolicy)
+  expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Security-Policy', expectedContentSecurityPolicy)
+})
+
+test('sets live headers', () => {
+  const mockRes = {
+    setHeader: jest.fn()
+  }
+
+  process.env.LIVE = 'true'
+
+  setHeaders(mockRes)
+
+  const expectedLiveContentSecurityPolicy = "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self'; frame-src embed.la1tv.co.uk; object-src 'none'; worker-src 'self'; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; upgrade-insecure-requests; connect-src 'self';"
+  expect(mockRes.setHeader).toHaveBeenCalledWith('Strict-Transport-Security', `max-age=10`)
+  expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Security-Policy', expectedLiveContentSecurityPolicy)
+
+  delete process.env.LIVE
+})
+
+test('sets production headers', () => {
+  const mockRes = {
+    setHeader: jest.fn()
+  }
+
+  process.env.PRODUCTION = 'true'
+
+  setHeaders(mockRes)
+
+  const expectedProductionContentSecurityPolicy = "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; img-src 'self'; frame-src embed.la1tv.co.uk; object-src 'none'; worker-src 'self'; manifest-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none';"
+  expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Security-Policy', expectedProductionContentSecurityPolicy)
+
+  delete process.env.PRODUCTION
+})


### PR DESCRIPTION
Add's some security headers, mainly:
* Strict-Transport-Security
* X-Content-Type-Options
* Referrer Policy
* Feature Policy
* Content-Security-Policy
* X-XSS-Protection

The CSP sets `upgrade-insecure-requests` when `process.env.UPGRADE_INSECURE_REQUESTS ` is set, this is because we can't have it set when developing locally as it makes all localhost requests into https so it should only be set when deployed. As such I have documented this in a deployment doc for future reference.