### PR TITLE
Autobuild and Publish Docker Image to Docker Hub

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,43 +2,50 @@ name: "Docker Build and Push"
 
 on:
   push:
-    branches:
-      - "main"
+    branches: [ '*' ]
+    tags: [ '*' ]
 
 jobs:
-  build:
+  build-image:
+
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.x]
+    
+    name: Build and Upload Docker Image
+    
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-      - run: npm install --global yarn
-      - run: cd $GITHUB_WORKSPACE && yarn install
-      # Run the build
-      - run: cp $GITHUB_WORKSPACE/config-example.json $GITHUB_WORKSPACE/config.json
-      - run: cd $GITHUB_WORKSPACE && yarn build
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/clockbox:latest
+    - uses: actions/checkout@v3
+
+    - name: Extract metadata - Stable
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: la1tv/website-frontend
+        # type=match,pattern=(.*) is untested and will need testing
+        tags: |
+            type=raw,value=stable
+            type=match,pattern=(.*)
+
+    - name: Extract metadata - Beta
+      if: ${{ startsWith(github.ref, 'refs/tags/') == false }}
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: la1tv/website-frontend
+        tags: |
+            type=raw,value=beta
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Extract metadata - Stable
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      id: meta
+      id: meta-stable
       uses: docker/metadata-action@v4
       with:
         images: la1tv/website-frontend
@@ -25,10 +25,11 @@ jobs:
         tags: |
             type=raw,value=stable
             type=match,pattern=(.*)
+            type=raw,value=beta
 
     - name: Extract metadata - Beta
       if: ${{ startsWith(github.ref, 'refs/tags/') == false }}
-      id: meta
+      id: meta-beta
       uses: docker/metadata-action@v4
       with:
         images: la1tv/website-frontend
@@ -41,11 +42,22 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
-    - name: Build and push
+    - name: Build and push - Stable
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
       uses: docker/build-push-action@v3
       with:
         context: .
         file: ./Dockerfile
         push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.meta-stable.outputs.tags }}
+        labels: ${{ steps.meta-stable.outputs.labels }}
+
+    - name: Build and push - Beta
+      if: ${{ startsWith(github.ref, 'refs/tags/') == false }}
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: ${{ steps.meta-beta.outputs.tags }}
+        labels: ${{ steps.meta-beta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,8 +24,8 @@ jobs:
         # type=match,pattern=(.*) is untested and will need testing
         tags: |
             type=raw,value=stable
-            type=match,pattern=(.*)
-            type=raw,value=beta
+            type=ref,event=tag
+            type=ref,event=branch,prefix=beta-
 
     - name: Extract metadata - Beta
       if: ${{ startsWith(github.ref, 'refs/tags/') == false }}
@@ -34,7 +34,7 @@ jobs:
       with:
         images: la1tv/website-frontend
         tags: |
-            type=raw,value=beta
+            type=ref,event=branch,prefix=beta-
 
     - name: Login to Docker Hub
       uses: docker/login-action@v2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,44 @@
+name: "Docker Build and Push"
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm install --global yarn
+      - run: cd $GITHUB_WORKSPACE && yarn install
+      # Run the build
+      - run: cp $GITHUB_WORKSPACE/config-example.json $GITHUB_WORKSPACE/config.json
+      - run: cd $GITHUB_WORKSPACE && yarn build
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/clockbox:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,21 @@
 # Dockerfile
 
 # base image
-FROM node:16
+FROM node:18
 
 # create & set working directory
 WORKDIR /opt/app
 
-# Install packages using Yarn
-ADD package.json yarn.lock /tmp/
-RUN cd /tmp && yarn
-RUN mkdir -p /opt/app && cd /opt/app && ln -s /tmp/node_modules
-
 # Copy the code
+RUN mkdir -p /opt/app
 ADD . /opt/app
 
-# start app
-RUN yarn run build
+# Install packages using Yarn
+RUN cd /opt/app && yarn install
+
+# build app
+RUN cd /opt/app && yarn run build
+# setup docker to expose our port
 EXPOSE 3000
-CMD yarn run start
+# Commands to be run when the image starts
+CMD cd /opt/app && yarn run start

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
 # Dockerfile
 
 # base image
-FROM node:18
+FROM node:16
 
 # create & set working directory
 WORKDIR /opt/app
 
+# Install packages using Yarn
+ADD package.json yarn.lock /tmp/
+RUN cd /tmp && yarn
+RUN mkdir -p /opt/app && cd /opt/app && ln -s /tmp/node_modules
+
 # Copy the code
-RUN mkdir -p /opt/app
 ADD . /opt/app
 
-# Install packages using Yarn
-RUN cd /opt/app && yarn install
-
-# build app
-RUN cd /opt/app && yarn run build
-# setup docker to expose our port
+# start app
+RUN yarn run build
 EXPOSE 3000
-# Commands to be run when the image starts
-CMD cd /opt/app && yarn run start
+CMD yarn run start


### PR DESCRIPTION
This should auto build and branches in the git repo (as well as any tags) and then upload them to Docker Hub with the correct image name.

It is worth noting that ANY tag that is created will push to the stable image so we may want to create a naming scheme to narrow this so tags only containing a certain prefix get uploaded to stable if we want to use tags for anything other than stable builds. All tags will also be pushed to their own image with the tag as the image name.

Any build that is not tagged will be uploaded as `beta-branchname` where `branchname` is the name of the branch. If there is already a `beta-branchname` it will be overwritten (meaning we dont have tonnes of images for each commit).

I also modified the dockerfile to use nodejs 18 and to install the node modules in the application directory which is where they are supposed to be stored (there is no need to store them in /tmp on an image which should be static).

This is a draft PR as these changes need further testing and reviewing.